### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Screenshot
 --------------------
 ![AMBubbleTableViewController](https://raw.githubusercontent.com/andreamazz/AMBubbleTableView/master/screenshot.gif)
 
-Setup with Cocoapods
+Setup with CocoaPods
 --------------------
 * Add ```pod 'AMBubbleTableViewController'``` to your Podfile
 * Run ```pod install```
@@ -21,7 +21,7 @@ Setup with Cocoapods
 * Subclass ```AMBubbleTableViewController``` from your controller
 * Provide a ```AMBubbleTableDataSource``` and ```AMBubbleTableDelegate```
 
-Setup without Cocoapods
+Setup without CocoaPods
 --------------------
 * Clone this repo
 * Add the ```AMBubbleTableViewController``` folder to your project


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
