### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AMBubbleTableViewController
 [![Build Status](https://travis-ci.org/andreamazz/AMBubbleTableView.png)](https://travis-ci.org/andreamazz/AMBubbleTableView)
 
 Simple implementation of a UITableView styled as chat bubbles. It's strongly based on Jesse Squires'  [MessagesTableViewController](https://github.com/jessesquires/MessagesTableViewController), since I needed to deeply customize the view, I decided to spawn a new library.  
-###Please note
+### Please note
 This library is no longer maintained. I strongly suggest to use Jesse's library, linked above. 
 Want to adopt this library? Contact me in the issue section. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
